### PR TITLE
iter.next() to next(iter)

### DIFF
--- a/09_dataloader.py
+++ b/09_dataloader.py
@@ -66,7 +66,7 @@ train_loader = DataLoader(dataset=dataset,
 
 # convert to an iterator and look at one random sample
 dataiter = iter(train_loader)
-data = dataiter.next()
+data = next(dataiter)
 features, labels = data
 print(features, labels)
 
@@ -97,6 +97,6 @@ train_loader = DataLoader(dataset=train_dataset,
 
 # look at one random sample
 dataiter = iter(train_loader)
-data = dataiter.next()
+data = next(dataiter)
 inputs, targets = data
 print(inputs.shape, targets.shape)

--- a/13_feedforward.py
+++ b/13_feedforward.py
@@ -35,7 +35,7 @@ test_loader = torch.utils.data.DataLoader(dataset=test_dataset,
                                           shuffle=False)
 
 examples = iter(test_loader)
-example_data, example_targets = examples.next()
+example_data, example_targets = next(examples)
 
 for i in range(6):
     plt.subplot(2,3,i+1)

--- a/14_cnn.py
+++ b/14_cnn.py
@@ -45,7 +45,7 @@ def imshow(img):
 
 # get some random training images
 dataiter = iter(train_loader)
-images, labels = dataiter.next()
+images, labels = next(dataiter)
 
 # show images
 imshow(torchvision.utils.make_grid(images))

--- a/16_tensorboard.py
+++ b/16_tensorboard.py
@@ -43,7 +43,7 @@ test_loader = torch.utils.data.DataLoader(dataset=test_dataset,
                                           shuffle=False)
 
 examples = iter(test_loader)
-example_data, example_targets = examples.next()
+example_data, example_targets = next(examples)
 
 for i in range(6):
     plt.subplot(2,3,i+1)


### PR DESCRIPTION
The new pytorch version does not allow the old command and causes the code to return errors when running. It is a small fix, that will especially help beginners.